### PR TITLE
Modified Sales Team Map - added profiles by region

### DIFF
--- a/output.css
+++ b/output.css
@@ -1236,6 +1236,10 @@ video {
   max-width: 80rem;
 }
 
+.max-w-\[150px\] {
+  max-width: 150px;
+}
+
 .max-w-xl {
   max-width: 36rem;
 }

--- a/views/page-sales-team-map.twig
+++ b/views/page-sales-team-map.twig
@@ -17,6 +17,44 @@
         
     </div>
 
+    <div class="md:container mx-auto mt-20">
+        <div class="w-10/12 mx-auto">
+            <div class="flex flex-col">
+                <h3 class="text-3xl text-pale-blue font-semibold uppercase">West Region</h3>
+                <div class="w-full flex flex-col md:flex-row mt-10 mb-16 flex-wrap gap-y-6 justify-between">
+                    {% for member in post.meta('midwest') %}
+                        <div class="w-full md:w-6/12 xl:w-3/12 px-4">
+                            <img src="{{member.image.url}}" alt="" class="max-w-[150px] mb-3">
+                                <p class="text-white text-xl font-semibold underline">{{member.name}}</p>
+                                <p class="text-white italic">{{member.title}}</p>
+                                <p class="text-white text-sm italic"><a href="mailto:{{member.email}}">{{member.email}}</a></p>
+                                <p class="text-white text-sm"><a href="tel:{{member.phone_number}}">{{member.phone_number}}</a></p> 
+                        </div>
+                    {% endfor %}
+                </div>
+
+            </div>
+            <div class="flex flex-col md:flex-row">
+                <h3 class="text-3xl text-pale-blue font-semibold uppercase">Northeast Region</h3>
+                {% for item in items %}
+                    
+                {% endfor %}
+            </div>
+            <div class="flex flex-col md:flex-row">
+                <h3 class="text-3xl text-pale-blue font-semibold uppercase">Southeast Region</h3>
+                {% for item in items %}
+                    
+                {% endfor %}
+            </div>
+            <div class="flex flex-col md:flex-row">
+                <h3 class="text-3xl text-pale-blue font-semibold uppercase">Midwest Region</h3>
+                {% for item in items %}
+                    
+                {% endfor %}
+            </div>
+        </div>   
+    </div>
+
 </section>
 
 <section>


### PR DESCRIPTION
Made changes to the Sales Map Page. 

Added Profiles with images, name, title, email, and phone that can be added via Advanced Custom Fields and are pulled into the twig template for displaying on the Sales Team Map page.